### PR TITLE
fix #3 no more duplicate mapping error when running test

### DIFF
--- a/examples/play/test/ApplicationSpec.scala
+++ b/examples/play/test/ApplicationSpec.scala
@@ -24,7 +24,7 @@ class ApplicationSpec extends PlaySpec with OneAppPerTest {
 
       status(home) mustBe OK
       contentType(home) mustBe Some("text/html")
-      contentAsString(home) must include ("Your new application is ready.")
+      contentAsString(home) must include ("Elm.ServerCounter.embed")
     }
 
   }
@@ -32,9 +32,9 @@ class ApplicationSpec extends PlaySpec with OneAppPerTest {
   "CountController" should {
 
     "return an increasing count" in {
-      contentAsString(route(app, FakeRequest(GET, "/count")).get) mustBe "0"
-      contentAsString(route(app, FakeRequest(GET, "/count")).get) mustBe "1"
-      contentAsString(route(app, FakeRequest(GET, "/count")).get) mustBe "2"
+      contentAsString(route(app, FakeRequest(GET, "/count")).get) mustBe "{ \"counter\": 0 }"
+      contentAsString(route(app, FakeRequest(GET, "/count")).get) mustBe "{ \"counter\": 1 }"
+      contentAsString(route(app, FakeRequest(GET, "/count")).get) mustBe "{ \"counter\": 2 }"
     }
 
   }

--- a/examples/play/test/IntegrationSpec.scala
+++ b/examples/play/test/IntegrationSpec.scala
@@ -14,7 +14,7 @@ class IntegrationSpec extends PlaySpec with OneServerPerTest with OneBrowserPerT
 
       go to ("http://localhost:" + port)
 
-      pageSource must include ("Your new application is ready.")
+      eventually { pageSource must include ("Increment Server") }
     }
   }
 }

--- a/src/main/scala/sbt/elm/SbtElm.scala
+++ b/src/main/scala/sbt/elm/SbtElm.scala
@@ -164,14 +164,20 @@ object SbtElm extends AutoPlugin {
     resourceGenerators <+= elmMake)
 
   override def projectSettings =
-    inConfig(Assets)(baseElmSettings ++ Seq(
-      resourceManaged in elmMake := webTarget.value / "elm" / "main")) ++
-      inConfig(TestAssets)(baseElmSettings ++ Seq(
-        resourceManaged in elmMake := webTarget.value / "elm" / "test")) ++ Seq(
+    inConfig(Assets)(
+      baseElmSettings ++ Seq(
+        resourceManaged in elmMake := webTarget.value / "elm" / "main"
+      )
+    )++ /* inConfig(TestAssets)(
+      baseElmSettings ++ Seq(
+        resourceManaged in elmMake := webTarget.value / "elm" / "test"
+      )
+    ) ++ */ Seq(
       elmMake := (elmMake in Assets).value,
       // FIXME elmPackage := (elmPackage in Assets).value,
       elmReactor := (elmReactor in Assets).value,
-      elmRepl := (elmRepl in Assets).value)
+      elmRepl := (elmRepl in Assets).value
+    )
 
   def doCompile(command: Seq[String], sourceFiles: Seq[File]): Seq[Problem] = {
     val (buffer, pscLogger) = logger


### PR DESCRIPTION
fix #3 no more duplicate mapping error when running test in a play project
also fixed the play project tests for the js-based counter